### PR TITLE
Update GDRE tools link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## setup
 
-1. download `GDRE_tools-standalone` from https://github.com/bruvzg/gdsdecomp/issues/88#issuecomment-1289829017 and extract it
+1. download `GDRE_tools-standalone` from https://github.com/bruvzg/gdsdecomp/releases and extract it
 1. assuming you extracted to `gdre_tools/`, `gdre_tools/gdre_tools.x86_64 --headless --output-dir=extracted
    --recover='/mnt/.../Steam/steamapps/common/Spellbook Demonslayers/Spellbook Demonslayers.pck'`
 1. `pip3 install -r requirements.txt -r requirements_extract.txt`


### PR DESCRIPTION
Translation extraction made it into the releases a while back, so this should just point to the most recent release.